### PR TITLE
Update examples/strandtest/strandtest.pde

### DIFF
--- a/examples/strandtest/strandtest.pde
+++ b/examples/strandtest/strandtest.pde
@@ -1,5 +1,5 @@
 #include "LPD8806.h"
-#include "SPI.h"
+// eh might as well get rid of this!.. thanks for the code. #include "SPI.h"
 
 // Example to control LPD8806-based RGB LED Modules in a strip
 


### PR DESCRIPTION
Just got rid of the SPI.h reference. It causes errors. thanks for the code. This is my first edit on gethub so please excuse my beginner nature. I was amazed that you made the code. I needed it for an ATTiny85 I programmed. Do you know why the Attiny does not accept SPI?  Is there a good reference material book or otherwise that would explain this stuff to me? My background is mechanical engineering. cheers, tom
