### PR TITLE
Update examples/longstrandtest/longstrandtest.pde

### DIFF
--- a/examples/longstrandtest/longstrandtest.pde
+++ b/examples/longstrandtest/longstrandtest.pde
@@ -1,5 +1,5 @@
 #include "LPD8806.h"
-#include "SPI.h"
+
 
 // Simple test for 160 (5 meters) of LPD8806-based RGB LED strip
 


### PR DESCRIPTION
just got ride of the SPI.h reference. it causes errors.
