### PR TITLE
Update examples/advancedLEDbeltKit/advancedLEDbeltKit.pde

### DIFF
--- a/examples/advancedLEDbeltKit/advancedLEDbeltKit.pde
+++ b/examples/advancedLEDbeltKit/advancedLEDbeltKit.pde
@@ -12,7 +12,6 @@
 // program also included with the LPD8806 library.
 
 #include <avr/pgmspace.h>
-#include "SPI.h"
 #include "LPD8806.h"
 #include "TimerOne.h"
 


### PR DESCRIPTION
just got ride of the SPI.h reference. it causes errors.
