### PR TITLE
Update examples/LEDbeltKit/LEDbeltKit.pde

### DIFF
--- a/examples/LEDbeltKit/LEDbeltKit.pde
+++ b/examples/LEDbeltKit/LEDbeltKit.pde
@@ -1,5 +1,4 @@
 #include "LPD8806.h"
-#include "SPI.h"
 
 // Example to control LPD8806-based RGB LED Modules in a strip!
 /*****************************************************************************/


### PR DESCRIPTION
just got ride of the SPI.h reference. it causes errors.
